### PR TITLE
fix: use SERIAL_PORT_HARDWARE for default SOLOMotorControllersUart constructor

### DIFF
--- a/src/SOLOMotorControllersUart.h
+++ b/src/SOLOMotorControllersUart.h
@@ -165,7 +165,7 @@ private:
     SOLOMotorControllersUtils *soloUtils;
 
 public:
-    SOLOMotorControllersUart(unsigned char _deviceAddress = 0, HardwareSerial &_serial = Serial, SOLOMotorControllers::UartBaudrate _baudrate = SOLOMotorControllers::UartBaudrate::RATE_115200, long _millisecondsTimeout = 50, int _packetFailureTrialAttempts = 5);
+    SOLOMotorControllersUart(unsigned char _deviceAddress = 0, HardwareSerial &_serial = SERIAL_PORT_HARDWARE, SOLOMotorControllers::UartBaudrate _baudrate = SOLOMotorControllers::UartBaudrate::RATE_115200, long _millisecondsTimeout = 50, int _packetFailureTrialAttempts = 5);
     static int lastError;
 
 private:


### PR DESCRIPTION
The "Serial" port on some Arduino hardware is type SoftwareSerial used only for the serial monitor and in these cases the code will fail to compile.
Per pins_arduino.h in each board variant, the macro SERIAL_PORT_HARDWARE will default to the first HardwareSerial port and this will allow the code to compile on such hardware.

SAMD boards like mkr1000 or mkrzero are examples of these boards where Serial is a SoftwareSerial and you must use Serial1 to get a HardwareSerial port.

Ref my [forum post here](https://www.solomotorcontrollers.com/forum/solo-arduino-library/solomotorcontrollersuart-h-assumes-serial-is-a-hardwareserial-port/)